### PR TITLE
Add some comments and use standard method when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ package main
 import "github.com/Tomasen/realip"
 
 func (h *Handler) ServeIndexPage(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	clientIP := realip.RealIP(r)
+	clientIP := realip.FromRequest(r)
 	log.Println("GET / from", clientIP)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
-a golang library that can get client's real public ip address from http request headers
+# RealIP
 
-[![Build Status](https://travis-ci.org/tomasen/realip.svg?branch=master)](https://travis-ci.org/Tomasen/realip)
 [![GoDoc](https://godoc.org/github.com/Tomasen/realip?status.svg)](http://godoc.org/github.com/Tomasen/realip)
 
+Go package that can be used to get client's real public IP, which usually useful for logging HTTP server.
 
-* follow the rule of X-FORWARDED-FOR/rfc7239
-* follow the rule of X-Real-Ip
-* lan/intranet IP address filtered
+### Feature
+
+* Follows the rule of X-Real-IP
+* Follows the rule of X-Forwarded-For
+* Exclude local or private address
+
+## Example
+
+```go
+package main
+
+import "github.com/Tomasen/realip"
+
+func (h *Handler) ServeIndexPage(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	clientIP := realip.RealIP(r)
+	log.Println("GET / from", clientIP)
+}
+```
 
 ## Developing
 

--- a/realip.go
+++ b/realip.go
@@ -1,7 +1,7 @@
 package realip
 
 import (
-	"log"
+	"errors"
 	"net"
 	"net/http"
 	"strings"
@@ -10,62 +10,75 @@ import (
 var cidrs []*net.IPNet
 
 func init() {
-	lancidrs := []string{
-		"127.0.0.1/8", "10.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.168.0.0/16", "::1/128", "fc00::/7",
+	maxCidrBlocks := []string{
+		"127.0.0.1/8",    // localhost
+		"10.0.0.0/8",     // 24-bit block
+		"172.16.0.0/12",  // 20-bit block
+		"192.168.0.0/16", // 16-bit block
+		"169.254.0.0/16", // link local address
+		"::1/128",        // localhost IPv6
+		"fc00::/7",       // unique local address IPv6
+		"fe80::/10",      // link local address IPv6
 	}
 
-	cidrs = make([]*net.IPNet, len(lancidrs))
-
-	for i, it := range lancidrs {
-		_, cidrnet, err := net.ParseCIDR(it)
-		if err != nil {
-			log.Fatalf("ParseCIDR error: %v", err) // assuming I did it right above
-		}
-
-		cidrs[i] = cidrnet
+	cidrs = make([]*net.IPNet, len(maxCidrBlocks))
+	for i, maxCidrBlock := range maxCidrBlocks {
+		_, cidr, _ := net.ParseCIDR(maxCidrBlock)
+		cidrs[i] = cidr
 	}
 }
 
-func isLocalAddress(addr string) bool {
+// isLocalAddress works by checking if the address is under private CIDR blocks.
+// List of private CIDR blocks can be seen on :
+//
+// https://en.wikipedia.org/wiki/Private_network
+//
+// https://en.wikipedia.org/wiki/Link-local_address
+func isPrivateAddress(address string) (bool, error) {
+	ipAddress := net.ParseIP(address)
+	if ipAddress == nil {
+		return false, errors.New("address is not valid")
+	}
+
 	for i := range cidrs {
-		myaddr := net.ParseIP(addr)
-		if cidrs[i].Contains(myaddr) {
-			return true
+		if cidrs[i].Contains(ipAddress) {
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
-// Request.RemoteAddress contains port, which we want to remove i.e.:
-// "[::1]:58292" => "[::1]"
-func ipAddrFromRemoteAddr(s string) string {
-	idx := strings.LastIndex(s, ":")
-	if idx == -1 {
-		return s
-	}
-	return s[:idx]
-}
-
-// RealIP return client's real public IP address
-// from http request headers.
+// RealIP return client's real public IP address from http request headers.
 func RealIP(r *http.Request) string {
-	hdr := r.Header
-	hdrRealIP := hdr.Get("X-Real-Ip")
-	hdrForwardedFor := hdr.Get("X-Forwarded-For")
+	// Fetch header value
+	xRealIP := r.Header.Get("X-Real-Ip")
+	xForwardedFor := r.Header.Get("X-Forwarded-For")
 
-	if len(hdrForwardedFor) == 0 && len(hdrRealIP) == 0 {
-		return ipAddrFromRemoteAddr(r.RemoteAddr)
+	// If both empty, return IP from remote address
+	if xRealIP == "" && xForwardedFor == "" {
+		var remoteIP string
+
+		// If there are colon in remote address, remove the port number
+		// otherwise, return remote address as is
+		if strings.ContainsRune(r.RemoteAddr, ':') {
+			remoteIP, _, _ = net.SplitHostPort(r.RemoteAddr)
+		} else {
+			remoteIP = r.RemoteAddr
+		}
+
+		return remoteIP
 	}
 
-	// X-Forwarded-For is potentially a list of addresses separated with ","
-	for _, addr := range strings.Split(hdrForwardedFor, ",") {
-		// return first non-local address
-		addr = strings.TrimSpace(addr)
-		if len(addr) > 0 && !isLocalAddress(addr) {
-			return addr
+	// Check list of IP in X-Forwarded-For and return the first global address
+	for _, address := range strings.Split(xForwardedFor, ",") {
+		address = strings.TrimSpace(address)
+		isPrivate, err := isPrivateAddress(address)
+		if !isPrivate && err == nil {
+			return address
 		}
 	}
 
-	return hdrRealIP
+	// If nothing succeed, return X-Real-IP
+	return xRealIP
 }

--- a/realip.go
+++ b/realip.go
@@ -49,8 +49,8 @@ func isPrivateAddress(address string) (bool, error) {
 	return false, nil
 }
 
-// RealIP return client's real public IP address from http request headers.
-func RealIP(r *http.Request) string {
+// FromRequest return client's real public IP address from http request headers.
+func FromRequest(r *http.Request) string {
 	// Fetch header value
 	xRealIP := r.Header.Get("X-Real-Ip")
 	xForwardedFor := r.Header.Get("X-Forwarded-For")
@@ -81,4 +81,9 @@ func RealIP(r *http.Request) string {
 
 	// If nothing succeed, return X-Real-IP
 	return xRealIP
+}
+
+// RealIP is depreciated, use FromRequest instead
+func RealIP(r *http.Request) string {
+	return FromRequest(r)
 }

--- a/realip_test.go
+++ b/realip_test.go
@@ -88,7 +88,7 @@ func TestRealIP(t *testing.T) {
 
 	// Run test
 	for _, v := range testData {
-		if actual := RealIP(v.request); v.expected != actual {
+		if actual := FromRequest(v.request); v.expected != actual {
 			t.Errorf("%s: expected %s but get %s", v.name, v.expected, actual)
 		}
 	}

--- a/realip_test.go
+++ b/realip_test.go
@@ -2,11 +2,10 @@ package realip
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 )
 
-func TestIsLocalAddr(t *testing.T) {
+func TestIsPrivateAddr(t *testing.T) {
 	testData := map[string]bool{
 		"127.0.0.0":   true,
 		"10.0.0.0":    true,
@@ -24,7 +23,12 @@ func TestIsLocalAddr(t *testing.T) {
 	}
 
 	for addr, isLocal := range testData {
-		if isLocalAddress(addr) != isLocal {
+		isPrivate, err := isPrivateAddress(addr)
+		if err != nil {
+			t.Errorf("fail processing %s: %v", addr, err)
+		}
+
+		if isPrivate != isLocal {
 			format := "%s should "
 			if !isLocal {
 				format += "not "
@@ -36,51 +40,56 @@ func TestIsLocalAddr(t *testing.T) {
 	}
 }
 
-func TestIpAddrFromRemoteAddr(t *testing.T) {
-	testData := map[string]string{
-		"127.0.0.1:8888": "127.0.0.1",
-		"ip:port":        "ip",
-		"ip":             "ip",
-		"12:34::0":       "12:34:",
-	}
-
-	for remoteAddr, expectedAddr := range testData {
-		if actualAddr := ipAddrFromRemoteAddr(remoteAddr); actualAddr != expectedAddr {
-			t.Errorf("ipAddrFromRemoteAddr of %s should be %s but get %s", remoteAddr, expectedAddr, actualAddr)
-		}
-	}
-}
-
 func TestRealIP(t *testing.T) {
-	newRequest := func(remoteAddr, hdrRealIP, hdrForwardedFor string) *http.Request {
+	// Create type and function for testing
+	type testIP struct {
+		name     string
+		request  *http.Request
+		expected string
+	}
+
+	newRequest := func(remoteAddr, xRealIP string, xForwardedFor ...string) *http.Request {
 		h := http.Header{}
-		h["X-Real-Ip"] = []string{hdrRealIP}
-		h["X-Forwarded-For"] = []string{hdrForwardedFor}
+		h.Set("X-Real-IP", xRealIP)
+		for _, address := range xForwardedFor {
+			h.Set("X-Forwarded-For", address)
+		}
+
 		return &http.Request{
 			RemoteAddr: remoteAddr,
 			Header:     h,
 		}
 	}
 
-	remoteAddr := "144.12.54.87"
-	anotherRemoteAddr := "119.14.55.11"
+	// Create test data
+	publicAddr1 := "144.12.54.87"
+	publicAddr2 := "119.14.55.11"
 	localAddr := "127.0.0.0"
 
-	testData := []struct {
-		expected string
-		request  *http.Request
-	}{
-		{remoteAddr, newRequest(remoteAddr, "", "")}, // no header
-		{remoteAddr, newRequest("", "", remoteAddr)}, // X-Forwarded-For: remoteAddr
-		{remoteAddr, newRequest("", remoteAddr, "")}, // X-RealIP: remoteAddr
-
-		// X-Forwarded-For: localAddr, remoteAddr, anotherRemoteAddr
-		{remoteAddr, newRequest("", "", strings.Join([]string{localAddr, remoteAddr, anotherRemoteAddr}, ", "))},
+	testData := []testIP{
+		{
+			name:     "No header",
+			request:  newRequest(publicAddr1, ""),
+			expected: publicAddr1,
+		}, {
+			name:     "Has X-Forwarded-For",
+			request:  newRequest("", "", publicAddr1),
+			expected: publicAddr1,
+		}, {
+			name:     "Has multiple X-Forwarded-For",
+			request:  newRequest("", "", localAddr, publicAddr1, publicAddr2),
+			expected: publicAddr2,
+		}, {
+			name:     "Has X-Real-IP",
+			request:  newRequest("", publicAddr1),
+			expected: publicAddr1,
+		},
 	}
 
+	// Run test
 	for _, v := range testData {
 		if actual := RealIP(v.request); v.expected != actual {
-			t.Errorf("expected %s but get %s", v.expected, actual)
+			t.Errorf("%s: expected %s but get %s", v.name, v.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Hi @tomasen, thanks for this package. I've made some changes which I explain below :

### Add some comments

When I saw list of [`lancidrs`](https://github.com/tomasen/realip/blob/master/realip.go#L13) for the first time, I was wondering why are those addresses are included as private address :

```go
lancidrs := []string{
	"127.0.0.1/8", "10.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.168.0.0/16", "::1/128", "fc00::/7",
}
```

To prevent confusion from the future contributor, I added some comments and Wikipedia links that explain about those address.

```go
maxCidrBlocks := []string{
	"127.0.0.1/8",    // localhost
	"10.0.0.0/8",     // 24-bit block
	"172.16.0.0/12",  // 20-bit block
	"192.168.0.0/16", // 16-bit block
	"169.254.0.0/16", // link local address
	"::1/128",        // localhost IPv6
	"fc00::/7",       // unique local address IPv6
	"fe80::/10",      // link local address IPv6
}
```

### Remove `log.Fatal` from `init()`

I think a library must not make a project panic when the library is **only imported** by the project. That's why I removed these [lines](https://github.com/tomasen/realip/blob/master/realip.go#L21) :

```go
if err != nil {
	log.Fatalf("ParseCIDR error: %v", err) // assuming I did it right above
}
```

Besides, those lines are not needed anyway, because the submitted value is fixed, which make there are no possibility that error happened when calling `ParseCIDR`.

### Use standard method for splitting IP address and port number in `r.RemoteAddr`

According to the documentation about [`RemoteAddr`](https://godoc.org/net/http#Request), it said that :

> RemoteAddr allows HTTP servers and other software to record the network address that sent the request, usually for logging. This field is not filled in by ReadRequest and has no defined format. The HTTP server in this package sets RemoteAddr to an **"IP:port"** address before invoking a handler.

Now, since `RemoteAddr` is always in "IP:port" format, we can simply use [`net.SplitHostPort`](https://godoc.org/net#SplitHostPort).

### Clean up the test file

In `TestRealIP`, I added `name` field to the struct, to make it easier to see which test scenario that failed.

### Rename the function's name

When updating readme, I found it's quite weird to write `realip.RealIP(r)`, so I changed it into `realip.FromRequest(r)`.